### PR TITLE
Check if OAuthException class is already defined

### DIFF
--- a/OAuth.php
+++ b/OAuth.php
@@ -26,8 +26,11 @@ THE SOFTWARE.
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
-  // pass
+
+if (!class_exists('OAuthException')) {
+  class OAuthException extends Exception {
+    // pass
+  }
 }
 
 class OAuthConsumer {


### PR DESCRIPTION
If this plugin is used on a server that has PHP’s [OAuth extension](http://php.net/manual/en/book.oauth.php) enabled, triggers a fatal error saying class is already defined.
